### PR TITLE
Auto prefix token with "bearer " if missing

### DIFF
--- a/lib/routific.rb
+++ b/lib/routific.rb
@@ -55,7 +55,7 @@ class Routific
   class << self
     # Sets the default access token to use
     def setToken(token)
-      @@token = (/bearer /.match(token).nil?) ? "bearer #{token}" : token
+      @@token = token
     end
 
     def token
@@ -70,10 +70,12 @@ class Routific
         raise ArgumentError, "access token must be set"
       end
 
+      prefixed_token = (/bearer /.match(token).nil?) ? "bearer #{token}" : token
+
       # Sends HTTP request to Routific API server
       response = RestClient.post('https://routific.com/api/vrp', 
         data.to_json,
-        'Authorization' => token,
+        'Authorization' => prefixed_token,
         content_type: :json,
         accept: :json
         )

--- a/lib/routific.rb
+++ b/lib/routific.rb
@@ -70,6 +70,7 @@ class Routific
         raise ArgumentError, "access token must be set"
       end
 
+      # Prefix the token with "bearer " if missing during assignment
       prefixed_token = (/bearer /.match(token).nil?) ? "bearer #{token}" : token
 
       # Sends HTTP request to Routific API server

--- a/lib/routific.rb
+++ b/lib/routific.rb
@@ -55,7 +55,7 @@ class Routific
   class << self
     # Sets the default access token to use
     def setToken(token)
-      @@token = (/bearer /.match(token).nil?) ? "bearer #{@@token}" : token
+      @@token = (/bearer /.match(token).nil?) ? "bearer #{token}" : token
     end
 
     def token

--- a/lib/routific.rb
+++ b/lib/routific.rb
@@ -55,11 +55,11 @@ class Routific
   class << self
     # Sets the default access token to use
     def setToken(token)
-      @@token = token
+      @@token = (/bearer /.match(token).nil?) ? "bearer #{@@token}" : token
     end
 
     def token
-      @@token
+      return @@token
     end
 
     # Returns the route using the specified access token, network, visits and fleet information
@@ -73,7 +73,7 @@ class Routific
       # Sends HTTP request to Routific API server
       response = RestClient.post('https://routific.com/api/vrp', 
         data.to_json,
-        'Authorization' => "bearer #{token}",
+        'Authorization' => token,
         content_type: :json,
         accept: :json
         )

--- a/lib/routific.rb
+++ b/lib/routific.rb
@@ -59,7 +59,7 @@ class Routific
     end
 
     def token
-      return @@token
+      @@token
     end
 
     # Returns the route using the specified access token, network, visits and fleet information


### PR DESCRIPTION
Auto prefix token with "bearer " if missing during assignment. Fixes #3 