### PR TITLE
Adds support for per route options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Ignore the gem builds
 routific-*.gem
+
+# Ignore local .bundle directory
+.bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    routific (1.0.1)
+    routific (1.1.0)
       json (~> 1.8)
       rest-client (~> 1.7)
 
@@ -50,3 +50,6 @@ DEPENDENCIES
   faker (~> 1.4)
   routific!
   rspec (~> 3.0)
+
+BUNDLED WITH
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ Optional arguments in params:
  - shift_end: this vehicle's end shift time (e.g. '17:00'). Default value is 23:59, if not specified.
  - capacity: the capacity that this vehicle can load
 
+`routific.setOptions( params )`
+
+Sets optional options onto the route requests.
+
+Optional arguments must be one of the following:
+
+- traffic
+- min_visits_per_vehicle
+- balance
+- min_vehicles
+- shortest_distance
+
 `routific.getRoute()`
 
 Returns the route using the previously provided network, visits and fleet information

--- a/lib/routific.rb
+++ b/lib/routific.rb
@@ -6,10 +6,11 @@ require_relative './routific/visit'
 require_relative './routific/vehicle'
 require_relative './routific/route'
 require_relative './routific/way_point'
+require_relative './routific/options'
 
 # Main class of this gem
 class Routific
-  attr_reader :token, :visits, :fleet
+  attr_reader :token, :visits, :fleet, :options
 
   # Constructor
   # token: Access token for Routific API
@@ -17,6 +18,7 @@ class Routific
     @token = token
     @visits = {}
     @fleet = {}
+    @options = {}
   end
 
   # Sets a visit for the specified location using the specified parameters
@@ -33,6 +35,12 @@ class Routific
     fleet[id] = RoutificApi::Vehicle.new(id, params)
   end
 
+  # Sets options with the specified params
+  # params: parameters for these options
+  def setOptions(params)
+    @options = RoutificApi::Options.new(params)
+  end
+
   # Returns the route using the previously provided visits and fleet information
   def getRoute
     data = {
@@ -40,6 +48,7 @@ class Routific
       fleet: fleet
     }
 
+    data[:options] = options if options
     Routific.getRoute(data, token)
   end
 

--- a/lib/routific/options.rb
+++ b/lib/routific/options.rb
@@ -1,0 +1,49 @@
+module RoutificApi
+  # This class represents a set of options for the request
+  class Options
+    VALID_PARAMS = %w{ traffic min_visits_per_vehicle balance min_vehicles shortest_distance }
+
+    attr_reader *VALID_PARAMS
+
+    def initialize(params)
+      # Validates the provided parameters
+      validate(params)
+
+      @traffic = params["traffic"]
+      @min_visits_per_vehicle = params["min_visits_per_vehicle"]
+      @balance = params["balance"]
+      @min_vehicles = params["min_vehicles"]
+      @shortest_distance = params["shortest_distance"]
+    end
+
+    def to_json(options)
+      as_json(options).to_json
+    end
+
+    # Returns the JSON representation of this object
+    # def to_json(options = nil)
+    def as_json(options = nil)
+      jsonData = {}
+      jsonData["traffic"] = self.traffic if self.traffic
+      jsonData["min_visits_per_vehicle"] = self.min_visits_per_vehicle if self.min_visits_per_vehicle
+      jsonData["balance"] = self.balance if self.balance
+      jsonData["shortest_distance"] = self.shortest_distance if self.shortest_distance
+      jsonData["min_vehicles"] = self.min_vehicles if self.min_vehicles
+
+      jsonData
+    end
+
+    private
+    # Validates the parameters being provided
+    # Raises an ArgumentError if any of the provided params is not supported
+    # Supported params are traffic, min_visits_per_vehicle, and balance
+    def validate(params)
+      invalid = params.keys.reject { |k| VALID_PARAMS.include?(k) }
+
+      if invalid.any?
+        invalid = invalid.join(",")
+        raise ArgumentError, "#{invalid} parameter is not supported"
+      end
+    end
+  end
+end

--- a/routific.gemspec
+++ b/routific.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name              = 'routific'
-  s.version           = '1.0.1'
-  s.date              = '2015-10-26'
+  s.version           = '1.1.0'
+  s.date              = '2016-04-16'
   s.add_runtime_dependency('rest-client', '~> 1.7')
   s.add_runtime_dependency('json', '~> 1.8')
   s.add_development_dependency('rspec', '~> 3.0')

--- a/spec/helper/factory.rb
+++ b/spec/helper/factory.rb
@@ -68,4 +68,19 @@ class Factory
   ROUTE_FITNESS = Faker::Lorem.word
   ROUTE_UNSERVED = [Faker::Lorem.word]
   ROUTE = RoutificApi::Route.new( ROUTE_STATUS, ROUTE_FITNESS, ROUTE_UNSERVED )
+
+  # Factory and constants for options
+  ROUTE_OPTIONS_TRAFFIC = "slow"
+  ROUTE_OPTIONS_MIN_VISITS_PER_VEHICLE = "2"
+  ROUTE_OPTIONS_BALANCE = "false"
+  ROUTE_OPTIONS_MIN_VEHICLES = "false"
+  ROUTE_OPTIONS_SHORTEST_DISTANCE = "false"
+  ROUTE_OPTIONS_PARAMS = {
+    "traffic"                => ROUTE_OPTIONS_TRAFFIC,
+    "min_visits_per_vehicle" => ROUTE_OPTIONS_MIN_VISITS_PER_VEHICLE,
+    "balance"                => ROUTE_OPTIONS_BALANCE,
+    "min_vehicles"           => ROUTE_OPTIONS_MIN_VEHICLES,
+    "shortest_distance"      => ROUTE_OPTIONS_SHORTEST_DISTANCE
+  }
+  ROUTE_OPTIONS = RoutificApi::Options.new(ROUTE_OPTIONS_PARAMS)
 end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -1,0 +1,61 @@
+require_relative './helper/spec_helper'
+
+describe RoutificApi::Options do
+  describe "valid parameters" do
+    subject(:options) { Factory::ROUTE_OPTIONS }
+
+    it "has traffic" do
+      expect(options.traffic).to eq(Factory::ROUTE_OPTIONS_TRAFFIC)
+    end
+
+    it "has min_visits_per_vehicle" do
+      expect(options.min_visits_per_vehicle).to eq(Factory::ROUTE_OPTIONS_MIN_VISITS_PER_VEHICLE)
+    end
+
+    it "has balance" do
+      expect(options.balance).to eq(Factory::ROUTE_OPTIONS_BALANCE)
+    end
+
+    it "has min_vehicles" do
+      expect(options.min_vehicles).to eq(Factory::ROUTE_OPTIONS_MIN_VEHICLES)
+    end
+
+    it "has shortest_distance" do
+      expect(options.shortest_distance).to eq(Factory::ROUTE_OPTIONS_SHORTEST_DISTANCE)
+    end
+
+    describe "#as_json" do
+      subject(:optionsJSON) { options.as_json }
+
+      it "has traffic" do
+        expect(optionsJSON["traffic"]).to eq(Factory::ROUTE_OPTIONS_TRAFFIC)
+      end
+
+      it "has min_visits_per_vehicle" do
+        expect(optionsJSON["min_visits_per_vehicle"]).to eq(Factory::ROUTE_OPTIONS_MIN_VISITS_PER_VEHICLE)
+      end
+
+      it "has balance" do
+        expect(optionsJSON["balance"]).to eq(Factory::ROUTE_OPTIONS_BALANCE)
+      end
+
+      it "has min_vehicles" do
+        expect(optionsJSON["min_vehicles"]).to eq(Factory::ROUTE_OPTIONS_MIN_VEHICLES)
+      end
+
+      it "has shortest_distance" do
+        expect(optionsJSON["shortest_distance"]).to eq(Factory::ROUTE_OPTIONS_SHORTEST_DISTANCE)
+      end
+    end
+  end
+
+  describe "provided invalid parameters" do
+    subject(:options) { RoutificApi::Options.new({
+      "bad_parameter" => "bad_parameter"
+      }) }
+
+    it "raises an ArgumentError" do
+      expect { options }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/routific_spec.rb
+++ b/spec/routific_spec.rb
@@ -20,6 +20,13 @@ describe Routific do
       end
     end
 
+    describe "#options" do
+      it "is instance of a Routific::Options" do
+        routific.setOptions(Factory::ROUTE_OPTIONS_PARAMS)
+        expect(routific.options).to be_instance_of(RoutificApi::Options)
+      end
+    end
+
     describe "#setVisit" do
       let(:id) { Faker::Lorem.word }
       before do
@@ -48,6 +55,24 @@ describe Routific do
 
       it "vehicle in fleet is instances of Vehicle" do
         expect(routific.fleet[id]).to be_instance_of(RoutificApi::Vehicle)
+      end
+    end
+
+    describe "#setOptions" do
+      before do
+        routific.setOptions(Factory::ROUTE_OPTIONS_PARAMS)
+      end
+
+      it "adds an options hash into options" do
+        expect(routific.options.traffic).to eq(Factory::ROUTE_OPTIONS_TRAFFIC)
+        expect(routific.options.min_visits_per_vehicle).to eq(Factory::ROUTE_OPTIONS_MIN_VISITS_PER_VEHICLE)
+        expect(routific.options.balance).to eq(Factory::ROUTE_OPTIONS_BALANCE)
+        expect(routific.options.min_vehicles).to eq(Factory::ROUTE_OPTIONS_MIN_VEHICLES)
+        expect(routific.options.shortest_distance).to eq(Factory::ROUTE_OPTIONS_SHORTEST_DISTANCE)
+      end
+
+      it "options is instance of RoutificApi::Options" do
+        expect(routific.options).to be_instance_of(RoutificApi::Options)
       end
     end
 
@@ -81,6 +106,21 @@ describe Routific do
       end
 
       it "returns a Route instance" do
+        route = routific.getRoute()
+        expect(route).to be_instance_of(RoutificApi::Route)
+      end
+
+      it "attaches optional data hash" do
+        routific.setOptions({
+          "traffic" => "slow"
+        })
+
+        data = {
+          visits: routific.visits,
+          fleet: routific.fleet,
+          options: routific.options
+        }
+
         route = routific.getRoute()
         expect(route).to be_instance_of(RoutificApi::Route)
       end


### PR DESCRIPTION
Currently the gem does not support setting per route options such as `traffic` or `balance`. This PR adds that support.