### PR TITLE
Wrapped Routific classes in a RoutificApi namespace to prevent collisions

### DIFF
--- a/lib/routific.rb
+++ b/lib/routific.rb
@@ -23,14 +23,14 @@ class Routific
   # id: ID of location to visit
   # params: parameters for this visit
   def setVisit(id, params={})
-    visits[id] = Visit.new(id, params)
+    visits[id] = RoutificApi::Visit.new(id, params)
   end
 
   # Sets a vehicle with the specified ID and parameters
   # id: vehicle ID
   # params: parameters for this vehicle
   def setVehicle(id, params)
-    fleet[id] = Vehicle.new(id, params)
+    fleet[id] = RoutificApi::Vehicle.new(id, params)
   end
 
   # Returns the route using the previously provided visits and fleet information
@@ -76,8 +76,8 @@ class Routific
         # Parse the HTTP request response to JSON
         jsonResponse = JSON.parse(response)
 
-        # Parse the JSON representation into a Route object
-        Route.parse(jsonResponse)
+        # Parse the JSON representation into a RoutificApi::Route object
+        RoutificApi::Route.parse(jsonResponse)
       rescue => e
         puts e
         errorResponse = JSON.parse e.response.body

--- a/lib/routific/location.rb
+++ b/lib/routific/location.rb
@@ -1,52 +1,54 @@
-# This class represents a location in the network
-class Location
-  attr_accessor :name, :lat, :lng
+module RoutificApi
+  # This class represents a location in the network
+  class Location
+    attr_accessor :name, :lat, :lng
 
-  # Constructor
-  #
-  # Required arguments in params:
-  # lat: Latitude of this location
-  # lng: Longitude of this location
-  #
-  # Optional arguments in params:
-  # name: Name of this location
-  def initialize(params)
-    # Validates the parameters provided
-    validate(params)
+    # Constructor
+    #
+    # Required arguments in params:
+    # lat: Latitude of this location
+    # lng: Longitude of this location
+    #
+    # Optional arguments in params:
+    # name: Name of this location
+    def initialize(params)
+      # Validates the parameters provided
+      validate(params)
 
-    @lat = params["lat"]
-    @lng = params["lng"]
-    @name = params["name"]
-  end
+      @lat = params["lat"]
+      @lng = params["lng"]
+      @name = params["name"]
+    end
 
-  def ==(another_location)
-    self.name == another_location.name &&
-      self.lat == another_location.lat &&
-      self.lng == another_location.lng
-  end
+    def ==(another_location)
+      self.name == another_location.name &&
+        self.lat == another_location.lat &&
+        self.lng == another_location.lng
+    end
 
-  def to_json(options = nil)
-    as_json(options).to_json
-  end
+    def to_json(options = nil)
+      as_json(options).to_json
+    end
 
-  # Returns the JSON representation of this object
-  # def to_json(options = nil)
-  def as_json(options = nil)
-    jsonData = {}
-    jsonData["name"] = self.name if self.name
-    jsonData["lat"] = self.lat
-    jsonData["lng"] = self.lng
+    # Returns the JSON representation of this object
+    # def to_json(options = nil)
+    def as_json(options = nil)
+      jsonData = {}
+      jsonData["name"] = self.name if self.name
+      jsonData["lat"] = self.lat
+      jsonData["lng"] = self.lng
 
-    jsonData
-  end
+      jsonData
+    end
 
-  private
-  # Validates the parameters being provided
-  # Raises an ArgumentError if any of the required parameters is not provided.
-  # Required parameters are: latitude and longitude
-  def validate(params)
-    if(params["lat"].nil? || params["lng"].nil?)
-      raise ArgumentError, "'lat' and 'lng' parameters must be provided"
+    private
+    # Validates the parameters being provided
+    # Raises an ArgumentError if any of the required parameters is not provided.
+    # Required parameters are: latitude and longitude
+    def validate(params)
+      if(params["lat"].nil? || params["lng"].nil?)
+        raise ArgumentError, "'lat' and 'lng' parameters must be provided"
+      end
     end
   end
 end

--- a/lib/routific/route.rb
+++ b/lib/routific/route.rb
@@ -1,48 +1,50 @@
-# This class represents the resulting route returned by the Routific API
-class Route
-  attr_reader :status, :fitness, :unserved, :vehicleRoutes
+module RoutificApi
+  # This class represents the resulting route returned by the Routific API
+  class Route
+    attr_reader :status, :fitness, :unserved, :vehicleRoutes
 
-  # Constructor
-  def initialize(status, fitness, unserved)
-    @status = status
-    @fitness = fitness
-    @unserved = unserved
-    @vehicleRoutes = Hash.new()
-  end
-
-  # Adds a new way point for the specified vehicle
-  def addWayPoint(vehicle_name, way_point)
-    if @vehicleRoutes[vehicle_name].nil?
-      # No previous way point was added for the specified vehicle, so create a new array
-      @vehicleRoutes[vehicle_name] = []
+    # Constructor
+    def initialize(status, fitness, unserved)
+      @status = status
+      @fitness = fitness
+      @unserved = unserved
+      @vehicleRoutes = Hash.new()
     end
-    # Adds the provided way point for the specified vehicle
-    @vehicleRoutes[vehicle_name] << way_point
-  end
 
-  class << self
-    # Parse the JSON representation of a route, and return it as a Route object
-    def parse(routeJson)
-      status = routeJson["status"]
-      fitness = routeJson["fitness"]
-      unserved = routeJson["unserved"]
-      route = Route.new(status, fitness, unserved)
-
-      # Get way points for each vehicles
-      routeJson["solution"].each do |vehicle_name, way_points|
-        # Get all way points for this vehicle
-        way_points.each do |waypoint_info|
-          # Get all information for this way point
-          location_id = waypoint_info["location_id"]
-          arrival_time = waypoint_info["arrival_time"]
-          finish_time = waypoint_info["finish_time"]
-          way_point = WayPoint.new(location_id, arrival_time, finish_time)
-          route.addWayPoint(vehicle_name, way_point)
-        end
+    # Adds a new way point for the specified vehicle
+    def addWayPoint(vehicle_name, way_point)
+      if @vehicleRoutes[vehicle_name].nil?
+        # No previous way point was added for the specified vehicle, so create a new array
+        @vehicleRoutes[vehicle_name] = []
       end
+      # Adds the provided way point for the specified vehicle
+      @vehicleRoutes[vehicle_name] << way_point
+    end
 
-      # Return the resulting Route object
-      route
+    class << self
+      # Parse the JSON representation of a route, and return it as a Route object
+      def parse(routeJson)
+        status = routeJson["status"]
+        fitness = routeJson["fitness"]
+        unserved = routeJson["unserved"]
+        route = RoutificApi::Route.new(status, fitness, unserved)
+
+        # Get way points for each vehicles
+        routeJson["solution"].each do |vehicle_name, way_points|
+          # Get all way points for this vehicle
+          way_points.each do |waypoint_info|
+            # Get all information for this way point
+            location_id = waypoint_info["location_id"]
+            arrival_time = waypoint_info["arrival_time"]
+            finish_time = waypoint_info["finish_time"]
+            way_point = RoutificApi::WayPoint.new(location_id, arrival_time, finish_time)
+            route.addWayPoint(vehicle_name, way_point)
+          end
+        end
+
+        # Return the resulting Route object
+        route
+      end
     end
   end
 end

--- a/lib/routific/vehicle.rb
+++ b/lib/routific/vehicle.rb
@@ -1,55 +1,57 @@
-# This class represents a vehicle in the fleet
-class Vehicle
-  attr_accessor :id, :start_location, :end_location, :shift_start, :shift_end, :capacity
+module RoutificApi
+  # This class represents a vehicle in the fleet
+  class Vehicle
+    attr_accessor :id, :start_location, :end_location, :shift_start, :shift_end, :capacity
 
-  # Constructor
-  #
-  # Required arguments in params:
-  # start_location: start location for this vehicle. Instance of Location
-  #
-  # Optional arguments in params:
-  # end_location: end location for this vehicle. Instance of Location
-  # shift_start: this vehicle's start shift time (e.g. '08:00'). Default value is 00:00, if not specified.
-  # shift_end: this vehicle's end shift time (e.g. '17:00'). Default value is 23:59, if not specified.
-  # capacity: the capacity that this vehicle can load
-  def initialize(id, params)
-    validate(params)
+    # Constructor
+    #
+    # Required arguments in params:
+    # start_location: start location for this vehicle. Instance of Location
+    #
+    # Optional arguments in params:
+    # end_location: end location for this vehicle. Instance of Location
+    # shift_start: this vehicle's start shift time (e.g. '08:00'). Default value is 00:00, if not specified.
+    # shift_end: this vehicle's end shift time (e.g. '17:00'). Default value is 23:59, if not specified.
+    # capacity: the capacity that this vehicle can load
+    def initialize(id, params)
+      validate(params)
 
-    @id = id
-    @start_location = Location.new(params["start_location"])
-    if params["end_location"]
-      @end_location = Location.new(params["end_location"])
+      @id = id
+      @start_location = RoutificApi::Location.new(params["start_location"])
+      if params["end_location"]
+        @end_location = RoutificApi::Location.new(params["end_location"])
+      end
+      @shift_start = params["shift_start"]
+      @shift_end = params["shift_end"]
+      @capacity = params["capacity"]
     end
-    @shift_start = params["shift_start"]
-    @shift_end = params["shift_end"]
-    @capacity = params["capacity"]
-  end
 
-  def to_json(options=nil)
-    as_json(options).to_json
-  end
+    def to_json(options=nil)
+      as_json(options).to_json
+    end
 
-  # Returns the JSON representation of this object
-  # def to_json(options = nil)
-  def as_json(options = nil)
-    jsonData = {}
-    jsonData["start_location"] = self.start_location.as_json
-    jsonData["end_location"] = self.end_location.as_json if self.end_location
-    jsonData["shift_start"] = self.shift_start if self.shift_start
-    jsonData["shift_end"] = self.shift_end if self.shift_end
-    jsonData["capacity"] = self.capacity if self.capacity
+    # Returns the JSON representation of this object
+    # def to_json(options = nil)
+    def as_json(options = nil)
+      jsonData = {}
+      jsonData["start_location"] = self.start_location.as_json
+      jsonData["end_location"] = self.end_location.as_json if self.end_location
+      jsonData["shift_start"] = self.shift_start if self.shift_start
+      jsonData["shift_end"] = self.shift_end if self.shift_end
+      jsonData["capacity"] = self.capacity if self.capacity
 
-    jsonData
-  end
+      jsonData
+    end
 
 
-  private
-  # Validates the parameters being provided
-  # Raises an ArgumentError if any of the required parameters is not provided.
-  # Required parameters are: location
-  def validate(params)
-    if params["start_location"].nil?
-      raise ArgumentError, "'start-location' parameter must be provided"
+    private
+    # Validates the parameters being provided
+    # Raises an ArgumentError if any of the required parameters is not provided.
+    # Required parameters are: location
+    def validate(params)
+      if params["start_location"].nil?
+        raise ArgumentError, "'start-location' parameter must be provided"
+      end
     end
   end
 end

--- a/lib/routific/visit.rb
+++ b/lib/routific/visit.rb
@@ -1,49 +1,51 @@
-# This class represents a location to be visited
-class Visit
-  attr_reader :id, :start, :end, :duration, :demand, :location
+module RoutificApi
+  # This class represents a location to be visited
+  class Visit
+    attr_reader :id, :start, :end, :duration, :demand, :location
 
-  # Constructor
-  #
-  # Optional arguments in params:
-  # start: the earliest time for this visit. Default value is 00:00, if not specified.
-  # end: the latest time for this visit. Default value is 23:59, if not specified.
-  # duration: the length of this visit in minutes
-  # demand: the capacity that this visit requires
-  # location: the location of the visit. Instance of Location
-  def initialize(id, params = {})
-    validate(params)
-    @id = id
-    @start = params["start"]
-    @end = params["end"]
-    @duration = params["duration"]
-    @demand = params["demand"]
-    @location = Location.new(params["location"])
-  end
+    # Constructor
+    #
+    # Optional arguments in params:
+    # start: the earliest time for this visit. Default value is 00:00, if not specified.
+    # end: the latest time for this visit. Default value is 23:59, if not specified.
+    # duration: the length of this visit in minutes
+    # demand: the capacity that this visit requires
+    # location: the location of the visit. Instance of Location
+    def initialize(id, params = {})
+      validate(params)
+      @id = id
+      @start = params["start"]
+      @end = params["end"]
+      @duration = params["duration"]
+      @demand = params["demand"]
+      @location = RoutificApi::Location.new(params["location"])
+    end
 
-  def to_json(options)
-    as_json(options).to_json
-  end
+    def to_json(options)
+      as_json(options).to_json
+    end
 
-  # Returns the JSON representation of this object
-  # def to_json(options = nil)
-  def as_json(options = nil)
-    jsonData = {}
-    jsonData["start"] = self.start if self.start
-    jsonData["end"] = self.end if self.end
-    jsonData["duration"] = self.duration if self.duration
-    jsonData["demand"] = self.demand if self.demand
-    jsonData["location"] = self.location.as_json
+    # Returns the JSON representation of this object
+    # def to_json(options = nil)
+    def as_json(options = nil)
+      jsonData = {}
+      jsonData["start"] = self.start if self.start
+      jsonData["end"] = self.end if self.end
+      jsonData["duration"] = self.duration if self.duration
+      jsonData["demand"] = self.demand if self.demand
+      jsonData["location"] = self.location.as_json
 
-    jsonData
-  end
+      jsonData
+    end
 
-  private
-  # Validates the parameters being provided
-  # Raises an ArgumentError if any of the required parameters is not provided.
-  # Required parameters are: location
-  def validate(params)
-    if params["location"].nil?
-      raise ArgumentError, "'location' parameter must be provided"
+    private
+    # Validates the parameters being provided
+    # Raises an ArgumentError if any of the required parameters is not provided.
+    # Required parameters are: location
+    def validate(params)
+      if params["location"].nil?
+        raise ArgumentError, "'location' parameter must be provided"
+      end
     end
   end
 end

--- a/lib/routific/way_point.rb
+++ b/lib/routific/way_point.rb
@@ -1,11 +1,13 @@
-# This class represents a location to visit in the route
-class WayPoint
-  attr_reader :location_id, :arrival_time, :finish_time
+module RoutificApi
+  # This class represents a location to visit in the route
+  class WayPoint
+    attr_reader :location_id, :arrival_time, :finish_time
 
-  # Constructor
-  def initialize(location_id, arrival_time, finish_time)
-    @location_id = location_id
-    @arrival_time = arrival_time
-    @finish_time = finish_time
+    # Constructor
+    def initialize(location_id, arrival_time, finish_time)
+      @location_id = location_id
+      @arrival_time = arrival_time
+      @finish_time = finish_time
+    end
   end
 end

--- a/spec/helper/factory.rb
+++ b/spec/helper/factory.rb
@@ -12,7 +12,7 @@ class Factory
     "lat"   => LOCATION_LATITUDE,
     "lng"   => LOCATION_LONGITUDE
     }
-  LOCATION = Location.new(LOCATION_PARAMS)
+  LOCATION = RoutificApi::Location.new(LOCATION_PARAMS)
 
   # Factory and constants for visit
   VISIT_ID = Faker::Lorem.word
@@ -31,7 +31,7 @@ class Factory
     "demand"    => VISIT_DEMAND,
     "location"  => VISIT_LOCATION
   }
-  VISIT = Visit.new(VISIT_ID, VISIT_PARAMS)
+  VISIT = RoutificApi::Visit.new(VISIT_ID, VISIT_PARAMS)
 
   # Factory and constants for vehicle
   VEHICLE_ID = Faker::Lorem.word
@@ -54,18 +54,18 @@ class Factory
     "shift_end"       => VEHICLE_SHIFT_END,
     "capacity"        => VEHICLE_CAPACITY
     }
-  VEHICLE = Vehicle.new(VEHICLE_ID, VEHICLE_PARAMS)
+  VEHICLE = RoutificApi::Vehicle.new(VEHICLE_ID, VEHICLE_PARAMS)
 
   # Factory and constants for way point
   WAY_POINT_LOCATION_ID = Faker::Lorem.word
   WAY_POINT_ARRIVAL_TIME = "09:00"
   WAY_POINT_FINISH_TIME = "09:10"
-  WAY_POINT = WayPoint.new( WAY_POINT_LOCATION_ID,
+  WAY_POINT = RoutificApi::WayPoint.new( WAY_POINT_LOCATION_ID,
     WAY_POINT_ARRIVAL_TIME, WAY_POINT_FINISH_TIME )
 
   # Factory and constants for route
   ROUTE_STATUS = Faker::Lorem.word
   ROUTE_FITNESS = Faker::Lorem.word
   ROUTE_UNSERVED = [Faker::Lorem.word]
-  ROUTE = Route.new( ROUTE_STATUS, ROUTE_FITNESS, ROUTE_UNSERVED )
+  ROUTE = RoutificApi::Route.new( ROUTE_STATUS, ROUTE_FITNESS, ROUTE_UNSERVED )
 end

--- a/spec/location_spec.rb
+++ b/spec/location_spec.rb
@@ -1,6 +1,6 @@
 require_relative './helper/spec_helper'
 
-describe Location do
+describe RoutificApi::Location do
   describe "valid parameters" do
     subject(:location) { Factory::LOCATION }
 
@@ -38,7 +38,7 @@ describe Location do
   end
 
   describe "missing 'lat' parameter" do
-    subject(:location) { Location.new({
+    subject(:location) { RoutificApi::Location.new({
       "name" => Factory::LOCATION_NAME,
       "lng" => Factory::LOCATION_LONGITUDE
       }) }
@@ -49,7 +49,7 @@ describe Location do
   end
 
   describe "missing 'lng' parameter" do
-    subject(:location) { Location.new({
+    subject(:location) { RoutificApi::Location.new({
       "name" => Factory::LOCATION_NAME,
       "lat" => Factory::LOCATION_LATITUDE
       }) }
@@ -60,7 +60,7 @@ describe Location do
   end
 
   describe "missing 'name' parameter" do
-    subject(:location) { Location.new({
+    subject(:location) { RoutificApi::Location.new({
       "lat" => Factory::LOCATION_LATITUDE,
       "lng" => Factory::LOCATION_LONGITUDE
       }) }

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -1,6 +1,6 @@
 require_relative './helper/spec_helper'
 
-describe Route do
+describe RoutificApi::Route do
   subject(:route) { Factory::ROUTE }
 
   it "has status" do

--- a/spec/routific_spec.rb
+++ b/spec/routific_spec.rb
@@ -31,7 +31,7 @@ describe Routific do
       end
 
       it "location 1 in visits is instances of Visit" do
-        expect(routific.visits[id]).to be_instance_of(Visit)
+        expect(routific.visits[id]).to be_instance_of(RoutificApi::Visit)
       end
     end
 
@@ -47,7 +47,7 @@ describe Routific do
       end
 
       it "vehicle in fleet is instances of Vehicle" do
-        expect(routific.fleet[id]).to be_instance_of(Vehicle)
+        expect(routific.fleet[id]).to be_instance_of(RoutificApi::Vehicle)
       end
     end
 
@@ -82,7 +82,7 @@ describe Routific do
 
       it "returns a Route instance" do
         route = routific.getRoute()
-        expect(route).to be_instance_of(Route)
+        expect(route).to be_instance_of(RoutificApi::Route)
       end
     end
   end
@@ -147,7 +147,7 @@ describe Routific do
           end
 
           it "returns a Route instance" do
-            expect(Routific.getRoute(@data)).to be_instance_of(Route)
+            expect(Routific.getRoute(@data)).to be_instance_of(RoutificApi::Route)
           end
         end
 
@@ -157,13 +157,13 @@ describe Routific do
           end
 
           it "returns a Route instance" do
-            expect(Routific.getRoute(@data, ENV["API_KEY"])).to be_instance_of(Route)
+            expect(Routific.getRoute(@data, ENV["API_KEY"])).to be_instance_of(RoutificApi::Route)
           end
 
           it "still successful even if missing prefix 'bearer ' in key" do
             key = ENV["API_KEY"].sub /bearer /, ''
             expect(/bearer /.match(key).nil?).to be true
-            expect(Routific.getRoute(@data, key)).to be_instance_of(Route)
+            expect(Routific.getRoute(@data, key)).to be_instance_of(RoutificApi::Route)
           end
         end
       end

--- a/spec/vehicle_spec.rb
+++ b/spec/vehicle_spec.rb
@@ -1,6 +1,6 @@
 require_relative './helper/spec_helper'
 
-describe Vehicle do
+describe RoutificApi::Vehicle do
   describe "valid parameters" do
     subject(:vehicle) { Factory::VEHICLE }
 
@@ -9,11 +9,11 @@ describe Vehicle do
     end
 
     it "has start_location" do
-      expect(vehicle.start_location).to eq(Location.new(Factory::VEHICLE_START_LOCATION))
+      expect(vehicle.start_location).to eq(RoutificApi::Location.new(Factory::VEHICLE_START_LOCATION))
     end
 
     it "has end_location" do
-      expect(vehicle.end_location).to eq(Location.new(Factory::VEHICLE_END_LOCATION))
+      expect(vehicle.end_location).to eq(RoutificApi::Location.new(Factory::VEHICLE_END_LOCATION))
     end
 
     it "has shift_start" do
@@ -54,7 +54,7 @@ describe Vehicle do
   end
 
   describe "missing 'start_location' parameter" do
-    subject(:vehicle) { Vehicle.new(Factory::VEHICLE_ID, {
+    subject(:vehicle) { RoutificApi::Vehicle.new(Factory::VEHICLE_ID, {
       "end_location"  => Factory::VEHICLE_END_LOCATION,
       "shift_start"   => Factory::VEHICLE_SHIFT_START,
       "shift_end"     => Factory::VEHICLE_SHIFT_END,
@@ -67,7 +67,7 @@ describe Vehicle do
   end
 
   describe "missing optional parameters" do
-    subject(:vehicle) { Vehicle.new(Factory::VEHICLE_ID, {
+    subject(:vehicle) { RoutificApi::Vehicle.new(Factory::VEHICLE_ID, {
       "start_location"  => Factory::VEHICLE_START_LOCATION
       }) }
 

--- a/spec/visit_spec.rb
+++ b/spec/visit_spec.rb
@@ -1,6 +1,6 @@
 require_relative './helper/spec_helper'
 
-describe Location do
+describe RoutificApi::Location do
   describe "valid parameters" do
     subject(:visit) { Factory::VISIT }
 
@@ -50,7 +50,7 @@ describe Location do
   end
 
   describe "missing location" do
-    subject(:visit) { Visit.new(Faker::Lorem.word, {}) }
+    subject(:visit) { RoutificApi::Visit.new(Faker::Lorem.word, {}) }
 
     it "raises an error" do
       expect { visit }.to raise_error(ArgumentError)
@@ -58,7 +58,7 @@ describe Location do
   end
 
   describe "missing optional parameters" do
-    subject(:visit) { Visit.new(Faker::Lorem.word, {
+    subject(:visit) { RoutificApi::Visit.new(Faker::Lorem.word, {
       "location" => {
         "lat" => Faker::Address.latitude.to_f,
         "lng" => Faker::Address.longitude.to_f,

--- a/spec/way_point_spec.rb
+++ b/spec/way_point_spec.rb
@@ -1,6 +1,6 @@
 require_relative './helper/spec_helper'
 
-describe Vehicle do
+describe RoutificApi::Vehicle do
   describe "valid parameters" do
     subject(:way_point) { Factory::WAY_POINT }
 


### PR DESCRIPTION
Best practice in Ruby gems is to wrap the internal classes of a gem to prevent collisions with other apps and gems. In the case of the `routific-gem`, the naming of the internal classes, while clear, uses common terms that are likely to already be used in the enclosing app.

This PR wraps those internal classes in the `RoutificApi` namespace to prevent such collisions. I left the base `Routific` class alone, as 1) that seems unique enough to be able to stand on its own and 2) to minimize backwards compatibility issues.

Updated the test suite as well, and all specs pass.