### PR TITLE
Adds method to provide the location_name on a waypoint

### DIFF
--- a/lib/routific/route.rb
+++ b/lib/routific/route.rb
@@ -34,10 +34,7 @@ module RoutificApi
           # Get all way points for this vehicle
           way_points.each do |waypoint_info|
             # Get all information for this way point
-            location_id = waypoint_info["location_id"]
-            arrival_time = waypoint_info["arrival_time"]
-            finish_time = waypoint_info["finish_time"]
-            way_point = RoutificApi::WayPoint.new(location_id, arrival_time, finish_time)
+            way_point = RoutificApi::WayPoint.new(waypoint_info)
             route.addWayPoint(vehicle_name, way_point)
           end
         end

--- a/lib/routific/way_point.rb
+++ b/lib/routific/way_point.rb
@@ -1,13 +1,14 @@
 module RoutificApi
   # This class represents a location to visit in the route
   class WayPoint
-    attr_reader :location_id, :arrival_time, :finish_time
+    attr_reader :location_id, :arrival_time, :finish_time, :location_name
 
     # Constructor
-    def initialize(location_id, arrival_time, finish_time)
-      @location_id = location_id
-      @arrival_time = arrival_time
-      @finish_time = finish_time
+    def initialize(options = {})
+      @location_id = options['location_id']
+      @arrival_time = options['arrival_time']
+      @finish_time = options['finish_time']
+      @location_name = options['location_name']
     end
   end
 end

--- a/spec/helper/factory.rb
+++ b/spec/helper/factory.rb
@@ -60,8 +60,13 @@ class Factory
   WAY_POINT_LOCATION_ID = Faker::Lorem.word
   WAY_POINT_ARRIVAL_TIME = "09:00"
   WAY_POINT_FINISH_TIME = "09:10"
-  WAY_POINT = RoutificApi::WayPoint.new( WAY_POINT_LOCATION_ID,
-    WAY_POINT_ARRIVAL_TIME, WAY_POINT_FINISH_TIME )
+  WAY_POINT_LOCATION_NAME = Faker::Lorem.word
+  WAY_POINT = RoutificApi::WayPoint.new({
+    'location_id'   => WAY_POINT_LOCATION_ID,
+    'arrival_time'  => WAY_POINT_ARRIVAL_TIME,
+    'finish_time'   => WAY_POINT_FINISH_TIME,
+    'location_name' => WAY_POINT_LOCATION_NAME
+  })
 
   # Factory and constants for route
   ROUTE_STATUS = Faker::Lorem.word

--- a/spec/way_point_spec.rb
+++ b/spec/way_point_spec.rb
@@ -15,5 +15,9 @@ describe RoutificApi::Vehicle do
     it "has finish_time" do
       expect(way_point.finish_time).to eq(Factory::WAY_POINT_FINISH_TIME)
     end
+
+    it "has a location name" do
+      expect(way_point.location_name).to eq(Factory::WAY_POINT_LOCATION_NAME)
+    end
   end
 end


### PR DESCRIPTION
Currently, a `WayPoint` does not provide a method to access the `location_name` attribute present in a vehicle solution. This PR adds that method, and also shifts generation of 'waypoints' to use an options hash, which is generally preferred to a longer list of parameters, and especially makes sense when generating the model from a JSON object.

     {
        "location_id": "order_3",
        "location_name": "800 Robson",
        "arrival_time": "08:10",
        "finish_time": "08:20"
      }