### PR TITLE
Add VCR for mocking of API response

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
@@ -16,6 +19,7 @@ GEM
     dotenv-deployment (0.0.2)
     faker (1.4.2)
       i18n (~> 0.5)
+    hashdiff (0.3.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.6.11)
@@ -38,9 +42,15 @@ GEM
     rspec-mocks (3.0.2)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.2)
+    safe_yaml (1.0.4)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    vcr (3.0.3)
+    webmock (2.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -50,6 +60,8 @@ DEPENDENCIES
   faker (~> 1.4)
   routific!
   rspec (~> 3.0)
+  vcr
+  webmock
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/routific.gemspec
+++ b/routific.gemspec
@@ -6,6 +6,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('json', '~> 1.8')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('faker', '~> 1.4')
+  s.add_development_dependency('vcr')
+  s.add_development_dependency('webmock')
   s.add_development_dependency('dotenv', '~> 0.11')
   s.summary           = 'routific API'
   s.description       = 'Gem to use Routific API'

--- a/spec/fixtures/vcr_cassettes/routific/api_response.yml
+++ b/spec/fixtures/vcr_cassettes/routific/api_response.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.routific.com/v1/vrp
+    body:
+      encoding: UTF-8
+      string: '{"visits":{"order_1":{"start":"9:00","end":"12:00","duration":10,"location":{"name":"6800
+        Cambie","lat":49.227107,"lng":-123.1163085}}},"fleet":{"vehicle_1":{"start_location":{"name":"800
+        Kingsway","lat":49.2553636,"lng":-123.0873365},"end_location":{"name":"800
+        Kingsway","lat":49.2553636,"lng":-123.0873365},"shift_start":"8:00","shift_end":"12:00"}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJfaWQiOiI1M2NmZjVkOWI4OTUxNTA4MDA5NzNjNTYiLCJpYXQiOjE0MDYxMzc4MTd9.yOX4fklzcG8O82fNWkDJ_slCDazctjGCDGYgvUqXhzw
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '353'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, Routific-App
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Aug 2016 13:26:56 GMT
+      Server:
+      - nginx/1.8.1
+      X-Request-Id:
+      - e7b6e4f1-faff-405c-a71d-f846c18ccbc9
+      X-Response-Time:
+      - 128 ms
+      Content-Length:
+      - '215'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4WOQQrCMBBFryKzLpIKas3WpUcQKbEddSBNIJNUpPTuTkWr
+        aMFsQv4j/78OOJqYGDRwqipkhgyij8aWMZgW5aIGQefLuVrJWb8o1RafTGXg
+        UlMmxxharB/B++GStRmwtymSd6A7aPFClfzOQe87sL4yA5FGkRhZKV4hiszI
+        nRnGoFBqtiN35qu5CTYhUDvYPlRAFXq5gD777vWhxiCLv32roXBrmiPhRN1G
+        KyXxiRzx5SPN1cTIWx5dPTH1R11a19Af+v4OXAhNg5UBAAA=
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 13:26:55 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/routific/api_response/get_route.yml
+++ b/spec/fixtures/vcr_cassettes/routific/api_response/get_route.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.routific.com/v1/vrp
+    body:
+      encoding: UTF-8
+      string: '{"visits":{"order_1":{"start":"9:00","end":"12:00","duration":10,"location":{"name":"6800
+        Cambie","lat":49.227107,"lng":-123.1163085}}},"fleet":{"vehicle_1":{"start_location":{"name":"800
+        Kingsway","lat":49.2553636,"lng":-123.0873365},"end_location":{"name":"800
+        Kingsway","lat":49.2553636,"lng":-123.0873365},"shift_start":"8:00","shift_end":"12:00"}},"options":{}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJfaWQiOiI1M2NmZjVkOWI4OTUxNTA4MDA5NzNjNTYiLCJpYXQiOjE0MDYxMzc4MTd9.yOX4fklzcG8O82fNWkDJ_slCDazctjGCDGYgvUqXhzw
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '366'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, Routific-App
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Aug 2016 13:26:55 GMT
+      Server:
+      - nginx/1.8.1
+      X-Request-Id:
+      - b6166e4c-307e-4d11-b7cc-39cc9c745490
+      X-Response-Time:
+      - 169 ms
+      Content-Length:
+      - '215'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4WOQQrCMBBFryKzLpIKas3WpUcQKbEddSBNIJNUpPTuTkWr
+        aMFsQv4j/78OOJqYGDRwqipkhgyij8aWMZgW5aIGQefLuVrJWb8o1RafTGXg
+        UlMmxxharB/B++GStRmwtymSd6A7aPFClfzOQe87sL4yA5FGkRhZKV4hiszI
+        nRnGoFBqtiN35qu5CTYhUDvYPlRAFXq5gD777vWhxiCLv32roXBrmiPhRN1G
+        KyXxiRzx5SPN1cTIWx5dPTH1R11a19Af+v4OXAhNg5UBAAA=
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 13:26:54 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/routific/api_response/with_data_hash.yml
+++ b/spec/fixtures/vcr_cassettes/routific/api_response/with_data_hash.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.routific.com/v1/vrp
+    body:
+      encoding: UTF-8
+      string: '{"visits":{"order_1":{"start":"9:00","end":"12:00","duration":10,"location":{"name":"6800
+        Cambie","lat":49.227107,"lng":-123.1163085}}},"fleet":{"vehicle_1":{"start_location":{"name":"800
+        Kingsway","lat":49.2553636,"lng":-123.0873365},"end_location":{"name":"800
+        Kingsway","lat":49.2553636,"lng":-123.0873365},"shift_start":"8:00","shift_end":"12:00"}},"options":{"traffic":"slow"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJfaWQiOiI1M2NmZjVkOWI4OTUxNTA4MDA5NzNjNTYiLCJpYXQiOjE0MDYxMzc4MTd9.yOX4fklzcG8O82fNWkDJ_slCDazctjGCDGYgvUqXhzw
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '382'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, Authorization, Routific-App
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Aug 2016 13:26:55 GMT
+      Server:
+      - nginx/1.8.1
+      X-Request-Id:
+      - 85b72633-9e5c-4b9c-a813-61b6cb456328
+      X-Response-Time:
+      - 202 ms
+      Content-Length:
+      - '216'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4WOywrCMBBFf0VmXSRWqZqtSz9BpMR21IE0gUxSkdJ/dyq+
+        0ILZhNxD7j0dcDQxMWjgVFXIDBlEH40tYzAtykUNgs6L6byQs3xSqi0+mMrA
+        paZMjjG0WN+D98MlazNgb1Mk70B30OKZKvk9A73rwPrKDEQaReLFSvEKUWRe
+        3JlhDFZKTbbkTnwxV8EmBGoH27sKqJVeFNBn370+1Bhk8bevGAo3pjkQjtSt
+        tVISH8kRnz/SmRoZecujq0em/qivdZ5Dv+/7G3NDHuSVAQAA
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 13:26:55 GMT
+recorded_with: VCR 3.0.3

--- a/spec/helper/spec_helper.rb
+++ b/spec/helper/spec_helper.rb
@@ -1,14 +1,25 @@
 require 'bundler/setup'
-Bundler.setup
-
-require 'faker'
-
 require 'dotenv'
-Dotenv.load
-
+require 'faker'
 require 'routific'
+require 'webmock'
+require 'vcr'
 
 require_relative './factory'
 
-RSpec.configure do |config|
+Bundler.setup
+Dotenv.load
+
+RSpec.configure do |c|
+  WebMock.enable!
+
+  VCR.configure do |vcr_config|
+    vcr_config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+    vcr_config.hook_into :webmock # or :fakeweb
+    vcr_config.extend VCR::RSpec::Macros
+
+    vcr_config.default_cassette_options = {
+      :match_requests_on => [:method, :uri, :headers]
+    }
+  end
 end

--- a/spec/routific_spec.rb
+++ b/spec/routific_spec.rb
@@ -106,8 +106,10 @@ describe Routific do
       end
 
       it "returns a Route instance" do
-        route = routific.getRoute()
-        expect(route).to be_instance_of(RoutificApi::Route)
+        VCR.use_cassette 'routific/api_response/get_route' do
+          route = routific.getRoute()
+          expect(route).to be_instance_of(RoutificApi::Route)
+        end
       end
 
       it "attaches optional data hash" do
@@ -121,8 +123,10 @@ describe Routific do
           options: routific.options
         }
 
-        route = routific.getRoute()
-        expect(route).to be_instance_of(RoutificApi::Route)
+        VCR.use_cassette 'routific/api_response/with_data_hash' do
+          route = routific.getRoute()
+          expect(route).to be_instance_of(RoutificApi::Route)
+        end
       end
     end
   end
@@ -187,7 +191,9 @@ describe Routific do
           end
 
           it "returns a Route instance" do
-            expect(Routific.getRoute(@data)).to be_instance_of(RoutificApi::Route)
+            VCR.use_cassette 'routific/api_response' do
+              expect(Routific.getRoute(@data)).to be_instance_of(RoutificApi::Route)
+            end
           end
         end
 
@@ -197,13 +203,17 @@ describe Routific do
           end
 
           it "returns a Route instance" do
-            expect(Routific.getRoute(@data, ENV["API_KEY"])).to be_instance_of(RoutificApi::Route)
+            VCR.use_cassette 'routific/api_response' do
+              expect(Routific.getRoute(@data, ENV["API_KEY"])).to be_instance_of(RoutificApi::Route)
+            end
           end
 
           it "still successful even if missing prefix 'bearer ' in key" do
             key = ENV["API_KEY"].sub /bearer /, ''
             expect(/bearer /.match(key).nil?).to be true
-            expect(Routific.getRoute(@data, key)).to be_instance_of(RoutificApi::Route)
+            VCR.use_cassette 'routific/api_response' do
+              expect(Routific.getRoute(@data, key)).to be_instance_of(RoutificApi::Route)
+            end
           end
         end
       end


### PR DESCRIPTION
I added VCR support for mocking of the API responses. There's pros and cons to stubbing out the API response, but I feel like in the case of this gem, the tests aren't really being used to monitor the stability of the Routific API, and the API is fairly stable to boot. So this will remove the need for multiple http requests while running the suite and make it finish much faster.
